### PR TITLE
fix deployment of .tar.gz archive to github release page

### DIFF
--- a/assets_release.sh
+++ b/assets_release.sh
@@ -5,14 +5,14 @@
 pushd src
 
 if [[ -f release_id.txt ]]; then
-  ID=(cat release_id.txt)
+  ID=$(cat release_id.txt)
   PYTHON_PKG_NAME="PythonPackage"
   PYTHON_PKG_FILENAME=$(ls dist | head -n 1)
 
   echo "Publishing python wheel with GitHub API"
-  curl https://uploads.github.com/repos/$TRAVIS_REPO_SLUG/releases/$ID/assets?name=$PYTHON_PKG_NAME&label=python-wheel&access_token=$GH_TOKEN \
-  --header "Content-Type: application/json" \
-  --data-binary @"dist/PYTHON_PKG_FILENAME"
+  curl "https://uploads.github.com/repos/$TRAVIS_REPO_SLUG/releases/$ID/assets?name=$PYTHON_PKG_NAME&label=python-targz&access_token=$GH_TOKEN" \
+  --header "Content-Type: application/octet-stream" \
+  --data-binary @"dist/$PYTHON_PKG_FILENAME"
 fi
 
 popd


### PR DESCRIPTION
`curl` program didn't take the gh asset address as a string with quotes & the name of the .tar.gz archive wasn't properly referenced

Fixes #16